### PR TITLE
Fix to reading device address

### DIFF
--- a/rtl/i2c_master.sv
+++ b/rtl/i2c_master.sv
@@ -202,7 +202,7 @@ always_comb begin
             _busy                           = 0;
             _saved_read_write               = read_write;
             _saved_register_address         = register_address;
-            _saved_device_address           = {device_address,1'b0};
+            _saved_device_address           = {device_address,1'b0};  // write
             _saved_mosi_data                = mosi_data;
             _serial_data                    = 1;
             _serial_clock                   = 1;
@@ -462,7 +462,7 @@ always_comb begin
                     3: begin
                         _state                      = S_START;
                         _post_state                 = S_WRITE_ADDR_R;
-                        _saved_device_address[0]    = 1;
+                        _saved_device_address       = {device_address,1'b1};  // read
                         _process_counter            = 0;
                     end
                 endcase


### PR DESCRIPTION
When restarting the FSM for reading a register after having done the write_device_w > write_register_address, the code was not properly resetting the device value, sending the wrong device id in writte_device_r